### PR TITLE
fix events reading

### DIFF
--- a/src/main/java/org/matsim/analysis/MatsimAnalysis.java
+++ b/src/main/java/org/matsim/analysis/MatsimAnalysis.java
@@ -266,10 +266,14 @@ public class MatsimAnalysis {
 		// #####################################
 		// Read the events file
 		// #####################################
-		
+
+		events1.initProcessing();
 		if (scenario1 != null) readEventsFile(runDirectory, runId, events1);
+		events1.finishProcessing();
+		events0.initProcessing();
 		if (scenario0 != null) readEventsFile(runDirectoryToCompareWith, runIdToCompareWith, events0);
-				
+		events0.finishProcessing();
+
 		// #####################################
 		// Post process and read plans file
 		// #####################################

--- a/src/main/java/org/matsim/analysis/MatsimAnalysis.java
+++ b/src/main/java/org/matsim/analysis/MatsimAnalysis.java
@@ -267,12 +267,16 @@ public class MatsimAnalysis {
 		// Read the events file
 		// #####################################
 
-		events1.initProcessing();
-		if (scenario1 != null) readEventsFile(runDirectory, runId, events1);
-		events1.finishProcessing();
-		events0.initProcessing();
-		if (scenario0 != null) readEventsFile(runDirectoryToCompareWith, runIdToCompareWith, events0);
-		events0.finishProcessing();
+		if (scenario1 != null){
+			events1.initProcessing();
+			readEventsFile(runDirectory, runId, events1);
+			events1.finishProcessing();
+		}
+		if (scenario0 != null){
+			events0.initProcessing();
+			readEventsFile(runDirectoryToCompareWith, runIdToCompareWith, events0);
+			events0.finishProcessing();
+		}
 
 		// #####################################
 		// Post process and read plans file

--- a/src/main/java/org/matsim/analysis/detailedPersonTripAnalysis/RunPersonTripAnalysis.java
+++ b/src/main/java/org/matsim/analysis/detailedPersonTripAnalysis/RunPersonTripAnalysis.java
@@ -85,9 +85,11 @@ public class RunPersonTripAnalysis {
 		events.addHandler(handler1);
 		
 		String eventsFile = outputDirectory + runId + ".output_events.xml.gz";
+		events.initProcessing();
 		MatsimEventsReader reader = new MatsimEventsReader(events);
 		reader.readFile(eventsFile);
-		
+		events.finishProcessing();
+
 		PersonTripAnalysis personTripAnalysis = new PersonTripAnalysis();
 		TripAnalysisFilter tripFilter = new TripAnalysisFilter("origin-and-destination-in-area");
 

--- a/src/main/java/org/matsim/analysis/dynamicLinkDemand/RunDynamicLinkDemandAnalysis.java
+++ b/src/main/java/org/matsim/analysis/dynamicLinkDemand/RunDynamicLinkDemandAnalysis.java
@@ -63,8 +63,10 @@ public class RunDynamicLinkDemandAnalysis {
 		
 		String eventsFile = outputDirectory + runId + ".output_events.xml.gz";
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+		events.initProcessing();
 		reader.readFile(eventsFile);
-		
+		events.finishProcessing();
+
 		handler.printResults(outputDirectory + runId + ".");
 		handler2.printResults(outputDirectory + runId + ".");
 	}

--- a/src/main/java/org/matsim/analysis/linkDemand/RunLinkDemandAnalysis.java
+++ b/src/main/java/org/matsim/analysis/linkDemand/RunLinkDemandAnalysis.java
@@ -63,8 +63,10 @@ public class RunLinkDemandAnalysis {
 		
 		String eventsFile = outputDirectory + runId + ".output_events.xml.gz";
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+		events.initProcessing();
 		reader.readFile(eventsFile);
-		
+		events.finishProcessing();
+
 		handler1.printResults(outputDirectory + runId + ".");
 		handler2.printResults(outputDirectory + runId + ".");
 	}

--- a/src/main/java/org/matsim/analysis/od/RunODAnalysis.java
+++ b/src/main/java/org/matsim/analysis/od/RunODAnalysis.java
@@ -69,8 +69,11 @@ public class RunODAnalysis {
 		events.addHandler(handler1);
 
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+
+		events.initProcessing();
 		reader.readFile(runDirectory + runId + ".output_events.xml.gz");
-		
+		events.finishProcessing();
+
 		Config config = ConfigUtils.createConfig();
 		config.network().setInputFile(runDirectory + runId + ".output_network.xml.gz");
 		config.network().setInputCRS(crs);

--- a/src/main/java/org/matsim/analysis/vehicleOperatingTimes/RunVehicleOperatingTimesAnalysis.java
+++ b/src/main/java/org/matsim/analysis/vehicleOperatingTimes/RunVehicleOperatingTimesAnalysis.java
@@ -43,8 +43,11 @@ public class RunVehicleOperatingTimesAnalysis {
 		
 		String eventsFile = outputDirectory + runId + ".output_events.xml.gz";
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+
+		events.initProcessing();
 		reader.readFile(eventsFile);
-		
+		events.finishProcessing();
+
 		handler.printResults(outputDirectory + runId + ".");
 	}
 

--- a/src/test/java/org/matsim/analysis/detailedPersonTripAnalysis/BasicPersonTripAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/detailedPersonTripAnalysis/BasicPersonTripAnalysisTest.java
@@ -178,10 +178,11 @@ public class BasicPersonTripAnalysisTest {
 		events.addHandler(basicHandler);
 		
 		log.info("Reading the events file...");
-		
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+		events.initProcessing();
 		reader.readFile(eventsFile);
-		
+		events.finishProcessing();
+
 		log.info("Reading the events file... Done.");
 		
 		return basicHandler;

--- a/src/test/java/org/matsim/analysis/detailedPersonTripAnalysis/PersonTripAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/detailedPersonTripAnalysis/PersonTripAnalysisTest.java
@@ -71,7 +71,9 @@ public class PersonTripAnalysisTest {
 		
 		log.info("Reading the events file...");
 		MatsimEventsReader reader = new MatsimEventsReader(events);
+		events.initProcessing();
 		reader.readFile(eventsFile);
+		events.finishProcessing();
 		log.info("Reading the events file... Done.");
 				
 		// plans

--- a/src/test/java/org/matsim/analysis/od/ODAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/od/ODAnalysisTest.java
@@ -76,8 +76,10 @@ public class ODAnalysisTest {
 			events.addHandler(handler1);
 
 			MatsimEventsReader reader = new MatsimEventsReader(events);
+			events.initProcessing();
 			reader.readFile(runDirectory + runId + ".output_events.xml.gz");
-			
+			events.finishProcessing();
+
 			Config config = ConfigUtils.createConfig();
 			config.network().setInputFile(networkFile);
 			config.network().setInputCRS("GK4");


### PR DESCRIPTION
- call initProcessing and finishProcessing on events manager before and after reading events

...fixes the issue that events can not be read (which was the case fo all matsim-berlin runs within the past months, for example)

However, that should be handled more elegantly and will hopefully be adressed by [the corresponding matsim ticket](https://github.com/matsim-org/matsim-libs/issues/1091)
eventually....

@ikaddoura mentioning you just for notice.

next step would be to update dependencies on this repo here (in matsim-berlin and other places...)

